### PR TITLE
fixed sign issue

### DIFF
--- a/c88.js
+++ b/c88.js
@@ -7,7 +7,7 @@ C88_STATE_HALT  = 2;
 function signed(i)
 {
   if ( i > 127 )
-    return i - 128;
+    return i - (128*2);
   else
     return i;
 };


### PR DESCRIPTION
When calculating the signed version of the number, you need to subtract twice the value of the MSB.
