### PR TITLE
Fix: HALF and DOUBLE are signed instructions

### DIFF
--- a/c88.js
+++ b/c88.js
@@ -75,8 +75,8 @@ function c88()
 
   this.instr[28]= function(i) { this.reg += 1; };		// INC
   this.instr[29]= function(i) { this.reg -= 1; };		// DEC
-  this.instr[30]= function(i) { this.reg *= 2; };		// DOUBLE
-  this.instr[31]= function(i) { this.reg /= 2; };		// HALF
+  this.instr[30]= function(i) { this.reg = signed(this.reg) * 2; };		// DOUBLE
+  this.instr[31]= function(i) { this.reg = signed(this.reg) / 2; };		// HALF
 
   this.debug = [];
 


### PR DESCRIPTION
I noticed this when the following program would run on the real thing
but not in the simulator:

?mem=65,5,161,34,66,254,45,69

JMP 1
LOAD 5
SHL 1
TSG 2
JMP 2
HALF (6) //doesn't take an argument but needs encoding with 6 as argument for LOAD 5 and TSL 5.
TSL 5
JMP 5
